### PR TITLE
the 1 to 1 relation user-local is setted properly

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,9 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
- 
+
   has_many :bookings
+  has_one :local
   has_one_attached :photo
 
   devise :database_authenticatable, :registerable,


### PR DESCRIPTION
I have modified the user model in order to have a relation 1to1 with a local. So, when we build the hole feature the user will be able to became a local as well.

I've tested the new model and its working. Here you can see that the relationship is established:

![image](https://github.com/user-attachments/assets/9425bfbb-508a-4763-9e75-1c5dcb43a4e2)

It doesn't let you add another local when the user-local relationship is established:

![image](https://github.com/user-attachments/assets/d4adde76-735d-478b-84d6-7b838314b92e)
